### PR TITLE
Updates JooqLookupManager's context field visibility to protected

### DIFF
--- a/src/main/java/org/cristalise/storage/jooqdb/lookup/JooqLookupManager.java
+++ b/src/main/java/org/cristalise/storage/jooqdb/lookup/JooqLookupManager.java
@@ -51,7 +51,7 @@ import org.jooq.DSLContext;
  */
 public class JooqLookupManager implements LookupManager {
 
-    private DSLContext context;
+    protected DSLContext context;
 
     private JooqItemHandler         items;
     private JooqDomainPathHandler   domains;


### PR DESCRIPTION
This is needed so that our extended class could define other handlers and use the same DSLContext.